### PR TITLE
fix enviroment transferability by removing Pipenv.lock and generating…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: init ci analyze build rebuild migrate lang-make lang-compile
 
 init:
+	rm Pipfile.lock && pipenv lock
 	pip install pipenv --upgrade
 	pipenv install --dev --skip-lock
 ci:


### PR DESCRIPTION
… a new

The Pipfile.lock from this repository is from the maintainer's computer enviroment.